### PR TITLE
Add healthz endpoint

### DIFF
--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -25,6 +25,7 @@ func NewRouter() *http.ServeMux {
 	router.HandleFunc(constants.EndpointNonce, handlers.Nonce())
 	router.HandleFunc(constants.EndpointRegister, handlers.Register())
 	router.HandleFunc(constants.EndpointToken, handlers.Token())
+	router.HandleFunc(constants.EndpointHealthz, handlers.Healthz())
 
 	return router
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,7 @@ var (
 	EndpointNonce          = getEnv("PSSO_ENDPOINTNONCE", "/nonce")
 	EndpointRegister       = getEnv("PSSO_ENDPOINTREGISTER", "/register")
 	EndpointToken          = getEnv("PSSO_ENDPOINTTOKEN", "/token")
+	EndpointHealthz        = getEnv("PSSO_ENDPOINTHEALTHZ", "/healthz")
 )
 
 func getEnv(key, fallback string) string {

--- a/pkg/handlers/healthz.go
+++ b/pkg/handlers/healthz.go
@@ -1,0 +1,13 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func Healthz() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("Request for /healthz")
+		w.Write([]byte("ok"))
+	}
+}


### PR DESCRIPTION
## Summary
- add `EndpointHealthz` constant with default `/healthz`
- implement `Healthz` handler returning plain text `ok`
- register healthz route in the local server

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b6009d2a88326b49ee216c4fba9e7