### PR TITLE
Fix json marshal handling

### DIFF
--- a/pkg/handlers/nonce.go
+++ b/pkg/handlers/nonce.go
@@ -47,7 +47,11 @@ func Nonce() http.HandlerFunc {
 			fmt.Println(err)
 			return
 		}
-		json, _ := json.Marshal(response)
-		w.Write(json)
+		payload, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		w.Write(payload)
 	}
 }

--- a/pkg/handlers/well-known.go
+++ b/pkg/handlers/well-known.go
@@ -81,8 +81,12 @@ func WellKnownJWKS() http.HandlerFunc {
 		// fmt.Println(string(requestDump))
 
 		fmt.Println("Request for .well-known/jwks.json")
-		response, _ := json.Marshal(jsonJWKS)
-		w.Write(response)
+		payload, err := json.Marshal(jsonJWKS)
+		if err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		w.Write(payload)
 	}
 }
 
@@ -98,7 +102,11 @@ func WellKnownAASA() http.HandlerFunc {
 		fmt.Println(string(requestDump))
 
 		fmt.Println("Request for .well-known/apple-app-site-association")
-		response, _ := json.Marshal(currentAASA)
-		w.Write(response)
+		payload, err := json.Marshal(currentAASA)
+		if err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		w.Write(payload)
 	}
 }


### PR DESCRIPTION
## Summary
- return 500 errors if json encoding fails
- avoid `json` as a variable name in handlers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b600638d083268edb6aa994fbaf98