### PR TITLE
Add local curl instructions for well‑known endpoints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,10 @@ docker compose -f ../authentik/docker-compose.yml \
 
 # check health endpoint
 curl -vk http://localhost:9100/healthz   # → "ok"
+
+# inspect well-known endpoints
+curl -vk http://localhost:9100/.well-known/jwks.json                 # → HTTP/200 & JSON
+curl -vk http://localhost:9100/.well-known/apple-app-site-association # → HTTP/200 & JSON
 ```
 
 If you visit <https://psso.argio.ch/.well-known/jwks.json> in a browser and


### PR DESCRIPTION
## Summary
- document how to curl the `/jwks.json` and `/apple-app-site-association` endpoints

## Testing
- `go vet ./...` *(fails: VerifyCredentials redeclared)*
- `go test ./...` *(fails to build for the same reason)*
- `docker ps` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b77e065a88326ab9ecb466a098530