### PR TITLE
Add missing env vars to env template

### DIFF
--- a/.env.psso
+++ b/.env.psso
@@ -35,4 +35,8 @@ PSSO_ENDPOINTTOKEN=/token
 
 # ───── Cloudflare Tunnel ───────────────────────────────────
 TUNNEL_TOKEN=REPLACE_WITH_TOKEN            # ← CF‑Dashboard › Access › Tunnels
+#
+# Additional configuration variables
+AUTHENTIK_BASE_URL=CHANGE_ME
+PSSO_ENDPOINTHEALTHZ=CHANGE_ME
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- compare constants with `.env.psso`
- add placeholders for `AUTHENTIK_BASE_URL` and `PSSO_ENDPOINTHEALTHZ`

## Testing
- `go vet ./...` *(fails: VerifyCredentials redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_685b77df61ac8326a04e6c1875046f3d