### PR TITLE
Fix Authentik credential function name clash

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ compose network and is exposed publicly via a **Cloudflare Tunnel** as
 ```
 .
 ├── cmd/
-│   └── authentik/               # VerifyCredentials implementation
+│   └── authentik/               # Authentik integrations
 ├── docker-compose.override.yml  # psso + cloudflared overlay
 ├── Dockerfile                   # builds the psso-server binary
 ├── .env.psso                    # example env‑file (edit & copy!)

--- a/cmd/authentik/authentik.go
+++ b/cmd/authentik/authentik.go
@@ -12,9 +12,9 @@ import (
 	"github.com/twocanoes/psso-server/pkg/constants"
 )
 
-// VerifyCredentials contacts the Authentik token endpoint using the Password
+// VerifyAndFetchRoles contacts the Authentik token endpoint using the Password
 // grant. It returns the roles derived from the user's groups.
-func VerifyCredentials(username, password string) ([]string, error) {
+func VerifyAndFetchRoles(username, password string) ([]string, error) {
 	if constants.AuthentikTokenEndpoint == "" ||
 		constants.AuthentikClientID == "" ||
 		constants.AuthentikClientSecret == "" {

--- a/pkg/handlers/token.go
+++ b/pkg/handlers/token.go
@@ -174,7 +174,7 @@ func Token() http.HandlerFunc {
 			claimUsername := userClaims.Username
 			claimPassword := userClaims.Password
 
-			roles, err := authentik.VerifyCredentials(claimUsername, claimPassword)
+			roles, err := authentik.VerifyAndFetchRoles(claimUsername, claimPassword)
 			if err != nil {
 				fmt.Println("invalid username or password")
 				return


### PR DESCRIPTION
## Summary
- rename authentik VerifyCredentials implementation that returns roles
- call the new `VerifyAndFetchRoles` helper from token handler
- update README directory comment

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b77dac6b4832690a2e74d756bbc80