### PR TITLE
Register authentik credential verifier

### DIFF
--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -7,8 +7,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
+	"github.com/twocanoes/psso-sdk-go/psso"
+	"github.com/twocanoes/psso-server/cmd/authentik"
 	"github.com/twocanoes/psso-server/pkg/constants"
 	"github.com/twocanoes/psso-server/pkg/handlers"
 )
@@ -105,6 +108,9 @@ func main() {
 	// set up handlers
 
 	handlers.CheckWellKnowns()
+
+	psso.RegisterCredentialVerifier(authentik.VerifyCredentials)
+	psso.SetAdminGroups(strings.Split(constants.AdminGroups, ","))
 
 	run()
 


### PR DESCRIPTION
## Summary
- extend the local server imports for authentication support
- register the authentik credential verifier and admin groups before running

## Testing
- `go build ./...` *(fails: VerifyCredentials redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_685b77d8b7748326bd01e54477a65f7d