### PR TITLE
Update module path and cleanup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "mode": "auto",
             "program": "${workspaceFolder}/cmd/local/main.go",
             "env": {
-                "PSSO_ISSUER":"idp.twocanoes.com",
+                "PSSO_ISSUER":"auth.argio.ch",
                 "PSSO_ADDRESS":":6443"
                 "JWKSFilepath": "c:\\psso\\jwks.json",
                 "TLSPrivateKeyPath": "c:\\certs\\privkey.pem",

--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,6 @@ Advanced paths (`PSSO_KEYPATH`, `PSSO_ENDPOINTJWKS` …) are pre‑populated in
 
 ## Contribution / License
 
-Code is MIT‑licensed (same as upstream Twocanoes).  
+Code is MIT‑licensed.
 Feel free to open PRs or issues in the [Argon‑Analytik](https://github.com/argon-analytik) org.
 PRs should pass `go vet` and the basic health‑check compose test.

--- a/cmd/authentik/authentik.go
+++ b/cmd/authentik/authentik.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/constants"
 )
 
 // VerifyAndFetchRoles contacts the Authentik token endpoint using the Password

--- a/cmd/authentik/login.go
+++ b/cmd/authentik/login.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/constants"
 )
 
 // tokenResponse represents a minimal subset of Authentik's token endpoint response.

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -9,8 +9,8 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
-	"github.com/twocanoes/psso-server/pkg/handlers"
+	"github.com/argon-analytik/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/handlers"
 )
 
 func NewRouter() *http.ServeMux {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/twocanoes/psso-server
+module github.com/argon-analytik/psso-server
 
 go 1.22
 

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/argon-analytik/psso-server/pkg/constants"
 	"github.com/twocanoes/psso-sdk-go/psso"
-	"github.com/twocanoes/psso-server/pkg/constants"
 )
 
 type Device struct {

--- a/pkg/handlers/nonce.go
+++ b/pkg/handlers/nonce.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
-	"github.com/twocanoes/psso-server/pkg/file"
+	"github.com/argon-analytik/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/file"
 )
 
 type NonceResponse struct {

--- a/pkg/handlers/register.go
+++ b/pkg/handlers/register.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
-	"github.com/twocanoes/psso-server/pkg/file"
+	"github.com/argon-analytik/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/file"
 )
 
 type PSSORegistration struct {

--- a/pkg/handlers/register_test.go
+++ b/pkg/handlers/register_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/twocanoes/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/constants"
 )
 
 func TestRegisterCreatesKeyFiles(t *testing.T) {

--- a/pkg/handlers/token.go
+++ b/pkg/handlers/token.go
@@ -12,11 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/argon-analytik/psso-server/cmd/authentik"
+	"github.com/argon-analytik/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/file"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/twocanoes/psso-sdk-go/psso"
-	"github.com/twocanoes/psso-server/cmd/authentik"
-	"github.com/twocanoes/psso-server/pkg/constants"
-	"github.com/twocanoes/psso-server/pkg/file"
 )
 
 func jwksPrivateKey() (*ecdsa.PrivateKey, error) {

--- a/pkg/handlers/well-known.go
+++ b/pkg/handlers/well-known.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/http/httputil"
 
+	"github.com/argon-analytik/psso-server/pkg/constants"
+	"github.com/argon-analytik/psso-server/pkg/file"
 	"github.com/twocanoes/psso-sdk-go/psso"
-	"github.com/twocanoes/psso-server/pkg/constants"
-	"github.com/twocanoes/psso-server/pkg/file"
 )
 
 var jsonJWKS JSONJWKS


### PR DESCRIPTION
## Summary
- rename module to `github.com/argon-analytik/psso-server`
- update imports under `cmd/` and `pkg/`
- adjust VSCode launch config issuer
- clean up README license line
- run `go mod tidy` and `go vet`

## Testing
- `go mod tidy`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b8315987c83268407f5144422fd74